### PR TITLE
Removing the Gemfile's :assets group, as this was removed in Rails 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,17 +31,17 @@ gem 'protected_attributes'      # For protecting model from mass assignment atta
 # gem 'mail'                # Action Mailer for sending emails
 # gem 'roadie'              # Easy HTML email conversion
 
+# Assets:
+gem 'jquery-rails'
+gem 'sass-rails'
+gem 'uglifier'
+
 group :production do
   gem 'rails_12factor'
   gem 'rails_stdout_logging'
   gem 'dalli'     
   gem 'memcachier'
   gem 'rails_serve_static_assets'
-end
-group :assets do
-  gem 'jquery-rails'
-  gem 'sass-rails'
-  gem 'uglifier'
 end
 
 group :development do

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,10 +3,9 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 
 if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
-  # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
+  # Require the gems listed in Gemfile, including any gems
+  # you've limited to :test, :development, or :production.
+  Bundler.require(*Rails.groups)
 end
 
 %w(defaults overrides).each do |type|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,9 +55,6 @@ Boilerplate::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable threaded mode
-  # config.threadsafe!
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Boilerplate::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true


### PR DESCRIPTION
Further reading:

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0-gemfile
http://stackoverflow.com/questions/16406204/why-did-rails4-drop-support-for-assets-group-in-the-gemfile